### PR TITLE
C01P03 / ts-node-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,6 @@
   "version": "1.0.0",
   "description": "TypeScript Node.js API",
   "main": "index.js",
-  "scripts": {
-    "build": "tsc",
-    "start": "npm run build && node dist/src/index.js",
-    "lint": "eslint ./src ./test --ext .ts",
-    "lint:fix": "eslint ./src ./test --ext .ts --fix",
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Darlley/node-typescript-api.git"
@@ -26,6 +19,14 @@
     "url": "https://github.com/Darlley/node-typescript-api/issues"
   },
   "homepage": "https://github.com/Darlley/node-typescript-api#readme",
+  "scripts": {
+    "build": "tsc",
+    "start": "yarn build && node dist/src/index.js",
+    "start:local": "ts-node-dev --transpile-only src/index.ts",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint ./src ./test --ext .ts",
+    "lint:fix": "eslint ./src ./test --ext .ts --fix"
+  },
   "dependencies": {
     "@overnightjs/core": "^1.7.6",
     "@types/express": "^4.17.13",


### PR DESCRIPTION
Instalação do ts-node-dev para rodar o projeto com arquivos .ts sem precisar transpilar para .js